### PR TITLE
correct namespace for import to match compas 0.7.1

### DIFF
--- a/src/compas_assembly/viewer/app.py
+++ b/src/compas_assembly/viewer/app.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from compas.viewers.core import App
+from compas_viewers.core import App
 
 from compas_assembly.viewer.view import View
 from compas_assembly.viewer.controller import Controller
@@ -45,4 +45,14 @@ class AssemblyViewer(App):
 
 if __name__ == '__main__':
 
-    pass
+    from compas_assembly.datastructures import Assembly
+    import compas_assembly
+    import os
+
+    assembly = Assembly.from_json(os.path.join(compas_assembly.DATA, 'stack.json'))
+
+    viewer = AssemblyViewer()
+
+    viewer.assembly = assembly
+    viewer.show()
+

--- a/src/compas_assembly/viewer/controller.py
+++ b/src/compas_assembly/viewer/controller.py
@@ -28,7 +28,7 @@ from compas.geometry import centroid_points
 from compas.utilities import hex_to_rgb
 from compas.utilities import flatten
 
-from compas.viewers import core
+from compas_viewers import core
 
 from compas_assembly.viewer.model import BlockView
 from compas_assembly.viewer.model import InterfaceView

--- a/src/compas_assembly/viewer/view.py
+++ b/src/compas_assembly/viewer/view.py
@@ -13,9 +13,9 @@ import compas
 from compas.utilities import hex_to_rgb
 from compas.utilities import flatten
 
-from compas.viewers.core import GLWidget
-from compas.viewers.core import Grid
-from compas.viewers.core import Axes
+from compas_viewers.core import GLWidget
+from compas_viewers.core import Grid
+from compas_viewers.core import Axes
 
 
 __all__ = ['View']


### PR DESCRIPTION
a quick correct viewer's import namespace from compas.viewers to compas_viewers. 