### PR TITLE
yield the interfaces one by one

### DIFF
--- a/src/compas_assembly/datastructures/assembly.py
+++ b/src/compas_assembly/datastructures/assembly.py
@@ -326,7 +326,8 @@ class Assembly(Datastructure):
 
         """
         for edge in self.graph.edges():
-            if (interfaces := self.edge_interfaces(edge)):
+            interfaces = self.edge_interfaces(edge)
+            if interfaces:
                 for interface in interfaces:
                     yield interface
 

--- a/src/compas_assembly/datastructures/assembly.py
+++ b/src/compas_assembly/datastructures/assembly.py
@@ -325,7 +325,8 @@ class Assembly(Datastructure):
 
         """
         for edge in self.graph.edges():
-            yield self.edge_interface(edge)
+            for interface in self.edge_interfaces(edge):
+                yield interface
 
     def node_block(self, node):
         """Retrieve the block corresponding to a graph node.

--- a/src/compas_assembly/datastructures/assembly.py
+++ b/src/compas_assembly/datastructures/assembly.py
@@ -326,8 +326,9 @@ class Assembly(Datastructure):
 
         """
         for edge in self.graph.edges():
-            for interface in self.edge_interfaces(edge):
-                yield interface
+            if (interfaces := self.edge_interfaces(edge)):
+                for interface in interfaces:
+                    yield interface
 
     def node_block(self, node):
         """Retrieve the block corresponding to a graph node.


### PR DESCRIPTION
Modification of the `assembly.interfaces()` method. Originally, it was returning the interfaces as lists, while now they are unpacked and returned one by one. Edges without interfaces are automatically skipped.